### PR TITLE
add flux script to manage cvmfs deployment

### DIFF
--- a/infrastructure/cluster/flux/cvmfs.yaml
+++ b/infrastructure/cluster/flux/cvmfs.yaml
@@ -1,0 +1,60 @@
+
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: csi-cvmfsplugin
+  namespace: kube-system
+spec:
+  interval: 1m
+  url: https://registry.cern.ch/chartrepo/cern
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: csi-cvmfsplugin
+  namespace: kube-system
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: cern/cvmfs-csi
+      version: "2.1.1"
+      sourceRef:
+        kind: HelmRepository
+        name: csi-cvmfsplugin
+        namespace: kube-system
+      interval: 1m
+  # VRE wiki explanation: https://github.com/vre-hub/vre/wiki/Components#cvmfs---cern-vm-file-system 
+  values:
+    nodeplugin:
+      tolerations:
+        - key: "jupyter-role"
+          operator: "Exists"
+          effect: "NoSchedule"
+---
+# Based on docs and snippets from https://github.com/cvmfs-contrib/cvmfs-csi
+#
+# Create StorageClass for provisioning CVMFS automount volumes,
+# and a PersistentVolumeClaim that's fulfilled by the StorageClass.
+#
+# If Controller plugin is not deployed, follow the example in volume-pv-pvc.yaml.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: cvmfs
+provisioner: cvmfs.csi.cern.ch
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cvmfs
+  namespace: jhub
+spec:
+  accessModes:
+  - ReadOnlyMany
+  resources:
+    requests:
+      # Volume size value has no effect and is ignored
+      # by the driver, but must be non-zero.
+      storage: 1
+  storageClassName: cvmfs

--- a/infrastructure/cluster/tf/jhub/config.yaml
+++ b/infrastructure/cluster/tf/jhub/config.yaml
@@ -66,6 +66,16 @@ hub:
 singleuser:
   storage:
     type: none
+    extraVolumes:
+      - name: cvfms-from-vre
+        persistentVolumeClaim:
+          claimName: cvfms
+    extraVolumeMounts:
+      - name: cvfms-from-vre
+        mountPath: /cvfms
+        # CVMFS automount volumes must be mounted with HostToContainer mount propagation.
+        mountPropagation: HostToContainer  
+        
   image:
     name: ghcr.io/goseind/singleuser-base  # replace with updated image in vre-hub
     tag: latest


### PR DESCRIPTION
 - Add Flux CVMFS-CSI manifests (?) to manage the deployment of the new version of the CVMFS-CSI plugin
 - Modify `tf` jhub configuration to add cvmfs volumes and extra volumes 