### PR TITLE
Token refresh jhub

### DIFF
--- a/infrastructure/cluster/flux-v2/jhub/extraConfig-scripts.py
+++ b/infrastructure/cluster/flux-v2/jhub/extraConfig-scripts.py
@@ -1,0 +1,64 @@
+# This file just contains a copy of the scripts used in hub.extraConfig: in jhub-release.yaml
+
+# 00-ruci0-authenticator: |
+import pprint
+import os
+import warnings
+import requests
+from oauthenticator.generic import GenericOAuthenticator
+
+# custom authenticator to exchange the access token for a refresh token for rucio OIDC to work
+class RucioAuthenticator(GenericOAuthenticator):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.enable_auth_state = True
+
+    def exchange_token(self, token):
+        params = {
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'grant_type': 'urn:ietf:params:oauth:grant-type:token-exchange',
+            'subject_token': token,
+            'scope': 'openid email profile',
+            'audience': 'rucio'
+        }
+        response = requests.post(self.token_url, data=params)
+        access_token = response.json()['access_token']
+        return access_token
+    
+    async def pre_spawn_start(self, user, spawner):
+        auth_state = await user.get_auth_state()
+        pprint.pprint(auth_state)
+        if not auth_state:
+            # user has no auth state
+            return
+        
+        # define token environment variable from auth_state
+        spawner.environment['ACCESS_TOKEN'] = self.exchange_token(auth_state['access_token'])
+
+# set the above authenticator as the default
+c.JupyterHub.authenticator_class = RucioAuthenticator
+
+# enable authentication state
+c.GenericOAuthenticator.enable_auth_state = True
+
+if 'JUPYTERHUB_CRYPT_KEY' not in os.environ:
+    warnings.warn(
+        "Need JUPYTERHUB_CRYPT_KEY env for persistent auth_state.\n"
+        "    export JUPYTERHUB_CRYPT_KEY=$(openssl rand -hex 32)"
+    )
+    c.CryptKeeper.keys = [os.urandom(32)]
+
+# 01-refresher: |
+# also refer to: https://github.com/jupyterhub/kubespawner/issues/306#issuecomment-789718547
+import time
+import os
+
+while True:
+    exp_tk = os.environ.get('ACCESS_TOKEN')
+    c.KubeSpawner.environment.update(
+        {
+            "ACCESS_TOKEN": RucioAuthenticator.exchange_token(exp_tk)
+        }
+    )
+    time.sleep(3500)

--- a/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
+++ b/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
@@ -57,7 +57,7 @@ spec:
             - profile
             - email
       extraConfig:
-        token-exchange: |
+        00-ruci0-authenticator: |
           import pprint
           import os
           import warnings
@@ -80,8 +80,8 @@ spec:
                       'audience': 'rucio'
                   }
                   response = requests.post(self.token_url, data=params)
-                  refresh_token = response.json()['access_token']
-                  return refresh_token
+                  access_token = response.json()['access_token']
+                  return access_token
               
               async def pre_spawn_start(self, user, spawner):
                   auth_state = await user.get_auth_state()
@@ -91,8 +91,8 @@ spec:
                       return
                   
                   # define token environment variable from auth_state
-                  spawner.environment['REFRESH_TOKEN'] = self.exchange_token(auth_state['access_token'])
-          
+                  spawner.environment['ACCESS_TOKEN'] = self.exchange_token(auth_state['access_token'])
+                  
           # set the above authenticator as the default
           c.JupyterHub.authenticator_class = RucioAuthenticator
 
@@ -105,6 +105,18 @@ spec:
                   "    export JUPYTERHUB_CRYPT_KEY=$(openssl rand -hex 32)"
               )
               c.CryptKeeper.keys = [os.urandom(32)]
+        01-refresher: |
+          import time
+          import os
+
+          while True:
+              exp_tk = os.environ.get('ACCESS_TOKEN')
+              c.KubeSpawner.environment.update(
+                  {
+                      "ACCESS_TOKEN": RucioAuthenticator.exchange_token(exp_tk)
+                  }
+              )
+              time.sleep(3500)
     singleuser:
       defaultUrl: "/lab"
       # The liefcycle hooks are used to create the Rucio configuration file,
@@ -116,7 +128,7 @@ spec:
               - "sh"
               - "-c"
               - >
-                echo -n $REFRESH_TOKEN > /home/jovyan/token;
+                echo -n $ACCESS_TOKEN > /home/jovyan/token;
                 mkdir -p /opt/rucio/etc;
                 echo "[client]" >> /opt/rucio/etc/rucio.cfg;
                 echo "rucio_host = https://vre-rucio.cern.ch" >> /opt/rucio/etc/rucio.cfg;


### PR DESCRIPTION
ref #21 and subtask https://github.com/vre-hub/vre/issues/53
dep on #179 

This pr extends and modifies the token script for clarity (access token instead of refresh token) and adds a time-based refresh for the access token as set in the client.