### PR TITLE
Add oidc params for token refresh

### DIFF
--- a/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
+++ b/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
@@ -129,6 +129,7 @@ spec:
                 echo "oidc_issuer = escape" >> /opt/rucio/etc/rucio.cfg;
                 echo "auth_oidc_refresh_active true" >> /opt/rucio/etc/rucio.cfg;
                 echo "auth_oidc_refresh_before_exp 20" >> /opt/rucio/etc/rucio.cfg;
+                echo "oidc_polling = true" >> /opt/rucio/etc/rucio.cfg;
                 echo "auth_token_file_path = /home/jovyan/token" >> /opt/rucio/etc/rucio.cfg;
       networkPolicy:
         enabled: false

--- a/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
+++ b/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
@@ -125,6 +125,10 @@ spec:
                 echo "account = $JUPYTERHUB_USER" >> /opt/rucio/etc/rucio.cfg;
                 echo "auth_type = oidc" >> /opt/rucio/etc/rucio.cfg;
                 echo "oidc_audience = rucio" >> /opt/rucio/etc/rucio.cfg;
+                echo "oidc_scope = openid profile offline_access" >> /opt/rucio/etc/rucio.cfg;
+                echo "oidc_issuer = escape" >> /opt/rucio/etc/rucio.cfg;
+                echo "auth_oidc_refresh_active true" >> /opt/rucio/etc/rucio.cfg;
+                echo "auth_oidc_refresh_before_exp 20" >> /opt/rucio/etc/rucio.cfg;
                 echo "auth_token_file_path = /home/jovyan/token" >> /opt/rucio/etc/rucio.cfg;
       networkPolicy:
         enabled: false


### PR DESCRIPTION
Adding:

```
oidc_scope = openid profile offline_access
oidc_issuer = escape
auth_oidc_refresh_active true
auth_oidc_refresh_before_exp 20
```

To `rucio.cfg` for the user to try automatic token refresh by rucio itself (which is, however, independent of the plugin, which will still need the other token refresh mechanism).
