### PR TITLE
change certs dir to /tmp

### DIFF
--- a/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
+++ b/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
@@ -116,8 +116,8 @@ spec:
               - "sh"
               - "-c"
               - >
-                mkdir -p /certs;
-                echo -n $REFRESH_TOKEN > /certs/rucio_oauth.token;
+                mkdir -p /certs /tmp;
+                echo -n $REFRESH_TOKEN > /tmp/rucio_oauth.token;
                 mkdir -p /opt/rucio/etc;
                 echo "[client]" >> /opt/rucio/etc/rucio.cfg;
                 echo "rucio_host = https://vre-rucio.cern.ch" >> /opt/rucio/etc/rucio.cfg;
@@ -170,7 +170,7 @@ spec:
         RUCIO_NAME: "vre-rucio.cern.ch"
         RUCIO_SITE_NAME: "CERN"
         RUCIO_OIDC_AUTH: "file"
-        RUCIO_OIDC_FILE_NAME: "/certs/rucio_oauth.token"
+        RUCIO_OIDC_FILE_NAME: "/tmp/rucio_oauth.token"
         RUCIO_DEFAULT_AUTH_TYPE: "oidc"
         RUCIO_OAUTH_ID: "rucio"
         RUCIO_DEFAULT_INSTANCE: "vre-rucio.cern.ch"


### PR DESCRIPTION
jhub raises an exception if certs are savec/read(?) on /certs. Changing to /tmp as in the escape-gitops clu

```bash
2023-08-02 08:35:37,826 ERROR   [Errno 13] Permission denied: '/certs/tmpcz30eab9'
2023-08-02 08:35:37,826 ERROR
Rucio exited with an unexpected/unknown error.
Please rerun the last command with the "-v" option to gather more information.
If you're sure there is a problem with Rucio itself, please follow up at: https://github.com/rucio/rucio/issues
```