### PR TITLE
reapplying cvmfs pv, pvc and pod

### DIFF
--- a/infrastructure/cluster/flux-v2/cvmfs/cvmfs.yaml
+++ b/infrastructure/cluster/flux-v2/cvmfs/cvmfs.yaml
@@ -1,47 +1,47 @@
-# # Based on docs and snippets from https://github.com/cvmfs-contrib/cvmfs-csi
+# Based on docs and snippets from https://github.com/cvmfs-contrib/cvmfs-csi
 
-# # Create StorageClass for provisioning CVMFS automount volumes,
-# # and a PersistentVolumeClaim that's fulfilled by the StorageClass.
+# Create StorageClass for provisioning CVMFS automount volumes,
+# and a PersistentVolumeClaim that's fulfilled by the StorageClass.
 
-# # If Controller plugin is not deployed, follow the example in volume-pv-pvc.yaml.
-# apiVersion: storage.k8s.io/v1
-# kind: StorageClass
-# metadata:
-#   name: cvmfs
-# provisioner: cvmfs.csi.cern.ch
-# ---
-# apiVersion: v1
-# kind: PersistentVolumeClaim
-# metadata:
-#   name: cvmfs
-#   namespace: jhub
-# spec:
-#   accessModes:
-#   - ReadOnlyMany
-#   resources:
-#     requests:
-#       # Volume size value has no effect and is ignored
-#       # by the driver, but must be non-zero.
-#       storage: 1
-#   storageClassName: cvmfs
-# ---
-# apiVersion: v1
-# kind: Pod
-# metadata:
-#   name: cvmfs-all-repos
-#   namespace: jhub
-# spec:
-#   containers:
-#    - name: idle
-#      image: busybox
-#      imagePullPolicy: IfNotPresent
-#      command: [ "/bin/sh", "-c", "trap : TERM INT; (while true; do sleep 1000; done) & wait" ]
-#      volumeMounts:
-#        - name: cvmfs
-#          mountPath: /cvmfs
-#          # CVMFS automount volumes must be mounted with HostToContainer mount propagation.
-#          mountPropagation: HostToContainer
-#   volumes:
-#    - name: cvmfs
-#      persistentVolumeClaim:
-#        claimName: cvmfs
+# If Controller plugin is not deployed, follow the example in volume-pv-pvc.yaml.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: cvmfs
+provisioner: cvmfs.csi.cern.ch
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cvmfs
+  namespace: jhub
+spec:
+  accessModes:
+  - ReadOnlyMany
+  resources:
+    requests:
+      # Volume size value has no effect and is ignored
+      # by the driver, but must be non-zero.
+      storage: 1
+  storageClassName: cvmfs
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cvmfs-all-repos
+  namespace: jhub
+spec:
+  containers:
+   - name: idle
+     image: busybox
+     imagePullPolicy: IfNotPresent
+     command: [ "/bin/sh", "-c", "trap : TERM INT; (while true; do sleep 1000; done) & wait" ]
+     volumeMounts:
+       - name: cvmfs
+         mountPath: /cvmfs
+         # CVMFS automount volumes must be mounted with HostToContainer mount propagation.
+         mountPropagation: HostToContainer
+  volumes:
+   - name: cvmfs
+     persistentVolumeClaim:
+       claimName: cvmfs


### PR DESCRIPTION
Needed so that the cluster could fully erase the PV and PVC correctly.

Mental note for the future: There is no need of deleting the PV and PVC in case of CVMFS being re deployed.