### PR TITLE
chmod eos token and mount eos scratch path to jhub

### DIFF
--- a/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
+++ b/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
@@ -147,7 +147,7 @@ spec:
           - name: eulake-escape-data # mounts the EOS RSE needed for the Rucio JupiterLab extension
             hostPath:
               path: /var/eos-eulake-home/eulake/escape/data
-          - name: eulake-escape-data # mounts the EOS scratch space which is not an RSE
+          - name: eulake-escape-tmpdata # mounts the EOS scratch space which is not an RSE
             hostPath:
               path: /var/eos-eulake-home/eulake/escape/tmp_data
         extraVolumeMounts:
@@ -156,9 +156,12 @@ spec:
             # CVMFS automount volumes must be mounted with HostToContainer mount propagation.
             mountPropagation: HostToContainer
           - name: eulake-escape-data # mounts the EOS RSE needed for the Rucio JupiterLab extension
-            mountPath: /eos/escape/
+            mountPath: /eos/cern-eos-rse
             mountPropagation: HostToContainer
-            readOnly: true    
+            readOnly: true 
+          - name: eulake-escape-tmpdata # mounts the EOS RSE needed for the Rucio JupiterLab extension
+            mountPath: /eos/scatch-space
+            mountPropagation: HostToContainer
       image:
         name: ghcr.io/vre-hub/vre-singleuser
         tag: sha-40199b2


### PR DESCRIPTION
This PR adds a tmp data path on CERN EOS as additional scratch space and adjusts the token permission needed for the access to work. Also, this changes the naming convention of both mounts.