### PR TITLE
DaemonSet selector crashing flux

### DIFF
--- a/infrastructure/cluster/flux-v2/eos/eosfuse-daemonset.yaml
+++ b/infrastructure/cluster/flux-v2/eos/eosfuse-daemonset.yaml
@@ -6,9 +6,9 @@ metadata:
   name: eosfuse
   namespace: jhub
 spec:
-  selector:
-    matchLabels:
-      app: eosfuse
+  # selector:
+  #   matchLabels:
+  #     app: eosfuse
   template:
     metadata:
       labels:


### PR DESCRIPTION
Flux throws this message

```
NAME                     	REVISION          	SUSPENDED	READY	MESSAGE
kustomization/flux-system	main@sha1:06fa8b0f	False    	False	DaemonSet/jhub/eosfuse dry-run failed, reason: Invalid: DaemonSet.apps "eosfuse" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"eosfuse"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```

To be cleaned with eos debugging