### PR TITLE
avoid copying back the token to the jhub instance

### DIFF
--- a/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
+++ b/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
@@ -129,6 +129,7 @@ spec:
                 echo "account = $JUPYTERHUB_USER" >> /opt/rucio/etc/rucio.cfg;
                 echo "auth_type = oidc" >> /opt/rucio/etc/rucio.cfg;
                 echo "oidc_audience = rucio" >> /opt/rucio/etc/rucio.cfg;
+                echo "oidc_polling = true" >> /opt/rucio/etc/rucio.cfg;
                 echo "auth_token_file_path = /tmp/rucio_oauth.token" >> /opt/rucio/etc/rucio.cfg;
       networkPolicy:
         enabled: false


### PR DESCRIPTION
Ref #218 

the `oidc_polling = true` avoids copying back to the jhub terminal the token provided. 

@goseind @egazzarr why we took out the following args from the rucio cfg file ?
```
oidc_scope = openid profile offline_access
oidc_issuer = escape
auth_oidc_refresh_active = true
auth_oidc_refresh_before_exp = 20
```