### PR TITLE
changing link of EGI trustanchors 

### DIFF
--- a/containers/base-ops/Dockerfile
+++ b/containers/base-ops/Dockerfile
@@ -19,8 +19,8 @@ RUN pip install --upgrade pip
 USER root
 
 # EGI trust anchors
-RUN curl -o /etc/yum.repos.d/EGI-trustanchors.repo https://repository.egi.eu/sw/production/cas/1/current/repo-files/EGI-trustanchors.repo \
-    && yum -y update
+RUN curl -Lo /etc/yum.repos.d/egi-trustanchors.repo https://repository.egi.eu/sw/production/cas/1/current/repo-files/egi-trustanchors.repo \
+    && yum update -y 
 
 RUN yum -y install gfal2* python3-gfal2 xrootd-client voms-clients-java 
 RUN yum -y install ca-certificates ca-policy-egi-core

--- a/containers/eos-fuse-mount/Dockerfile
+++ b/containers/eos-fuse-mount/Dockerfile
@@ -20,7 +20,9 @@ RUN yum update -y \
 RUN yum update -y \
     && yum install -y wget voms-clients-java xrootd-client
 
-ADD yum-repo/EGI-trustanchors.repo /etc/yum.repos.d/EGI-trustanchors.repo
+RUN curl -Lo /etc/yum.repos.d/egi-trustanchors.repo https://repository.egi.eu/sw/production/cas/1/current/repo-files/egi-trustanchors.repo \
+    && yum update -y 
+    
 RUN yum install -y ca-policy-egi-core
 
 RUN mkdir -p /etc/vomses \

--- a/containers/rucio-client/Dockerfile
+++ b/containers/rucio-client/Dockerfile
@@ -6,9 +6,13 @@ LABEL maintainer="VRE Team @ CERN 22/23 - E. Garcia, E. Gazzarrini, D. Gosein"
 
 USER root
 
+RUN yum upgrade -y \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
 # EGI trust anchors
-RUN curl -Lo /etc/yum.repos.d/EGI-trustanchors.repo https://repository.egi.eu/sw/production/cas/1/current/repo-files/EGI-trustanchors.repo \
-    && yum -y update
+RUN curl -Lo /etc/yum.repos.d/egi-trustanchors.repo https://repository.egi.eu/sw/production/cas/1/current/repo-files/egi-trustanchors.repo \
+    && yum update -y 
 
 RUN yum clean metadata
 RUN yum -y install wget ca-certificates ca-policy-egi-core


### PR DESCRIPTION
as old one expired and no certificates were copied in the containers