### PR TITLE
adding dask config in jupyterhub helm chart 

### DIFF
--- a/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
+++ b/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
@@ -31,6 +31,18 @@ spec:
     - kind: ConfigMap
       name: jhub-profiles
       valuesKey: values.yaml
+
+    - kind: Secret
+      name: nb-vre-api-token
+      namespace: daskhub
+      valuesKey: apiToken
+      targetPath: hub.services.dask-gateway.apiToken
+    - kind: Secret
+      name: nb-vre-api-token
+      namespace: daskhub
+      valuesKey: apiToken
+      targetPath: dask-gateway.gateway.auth.jupyterhub.apiToken
+      
   values:
     proxy:
       service:
@@ -56,7 +68,24 @@ spec:
             - openid
             - profile
             - email
+
       extraConfig:
+
+        00-add-dask-gateway-values: |
+          # 1. Sets `DASK_GATEWAY__PROXY_ADDRESS` in the singleuser environment.
+          # 2. Adds the URL for the Dask Gateway JupyterHub service.
+          import os
+          gateway_address = "http://188.184.76.40/services/dask-gateway"
+          print("Setting DASK_GATEWAY__ADDRESS {} from HTTP service".format(gateway_address))
+         
+          # Internal address to connect to the Dask Gateway.
+          c.KubeSpawner.environment.setdefault("DASK_GATEWAY__ADDRESS", gateway_address)
+          
+          # Relative address for the dashboard link.
+          c.KubeSpawner.environment.setdefault("DASK_GATEWAY__PUBLIC_ADDRESS", "/services/dask-gateway/")
+          # Use JupyterHub to authenticate with Dask Gateway.
+          c.KubeSpawner.environment.setdefault("DASK_GATEWAY__AUTH__TYPE", "jupyterhub")
+
         token-exchange: |
           import pprint
           import os
@@ -106,6 +135,7 @@ spec:
                   "    export JUPYTERHUB_CRYPT_KEY=$(openssl rand -hex 32)"
               )
               c.CryptKeeper.keys = [os.urandom(32)]
+        
     singleuser:
       defaultUrl: "/lab"
       # The liefcycle hooks are used to create the Rucio configuration file,


### PR DESCRIPTION
In order for the Rucio extension to be compatible with Dask, an image has been added to the `jhub-profile-cm.yaml`. Once the user selects this image, he/she is able to see the Rucio extension (jupyter-server-proxy v3) along with a dask extension (which is also a bit older than the latest one, as we need jupyter-server-proxy v3). 

In order to test that the extension of Dask works, you can open a notebook and try to run:

```
import dask
import dask.distributed
from dask_gateway import Gateway
from dask_gateway import GatewayCluster
import dask.array as da
import requests
from dask_gateway import scheduler_preload
import os

gateway = Gateway()

gateway.list_clusters()

gateway.new_cluster()
```

Normally, with this edit to the jupyterhub helm release, you do not need to import any variables, which was before necessary, i.e.:

```
os.environ["JUPYTERHUB_API_TOKEN"] = <contained in secret nb-vre-api-token in daskhub namespace>
gateway = Gateway(
    address="http://188.184.76.40/services/dask-gateway",
    auth="jupyterhub")
```

making the usage of dask more seamless for the user. The dashboards still need a bit of workarounds. 