### PR TITLE
fix flux sync

### DIFF
--- a/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
+++ b/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
@@ -192,13 +192,13 @@ spec:
       #   jupyter-role: singleuser
 
       # elena adds the volumes with dask config
-        volumeMounts:
-        - name: dask-lab-configmap-gateway
-          mountPath: /home/jovyan/.config/dask/
-          subPath: gateway.yaml
-        - name: dask-lab-configmap-labextension
-          mountPath: /home/jovyan/.config/dask/
-          subPath: labextension.yaml
+        # volumeMounts:
+        # - name: dask-lab-configmap-gateway
+        #   mountPath: /home/jovyan/.config/dask/
+        #   subPath: gateway.yaml
+        # - name: dask-lab-configmap-labextension
+        #   mountPath: /home/jovyan/.config/dask/
+        #   subPath: labextension.yaml
 
       volumes:
       - name: dask-lab-configmap-gateway


### PR DESCRIPTION
flux message:

```bash
jhub            helmrelease/jhub-cvre           2.0.0           False           False   Helm upgrade failed: values don't meet the specifications of the schema(s) in the following chart(s):
                                                                                        jupyterhub:                                                                                          
                                                                                        - singleuser: Additional property volumes is not allowed                                             
                                                                                        - singleuser.image: Additional property volumeMounts is not allowed                                  
                                                                                                                                            
```                                                                                                                                           