### PR TITLE
Update jhub config

### DIFF
--- a/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
+++ b/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
@@ -217,7 +217,7 @@ spec:
 
       cmd: null
       extraEnv:
-        JUPYTERHUB_SINGLEUSER_APP: "notebook.notebookapp.NotebookApp"
+        JUPYTERHUB_SINGLEUSER_APP: "jupyter-server"
         RUCIO_MODE: "replica"
         RUCIO_WILDCARD_ENABLED: "1"
         RUCIO_BASE_URL: "https://vre-rucio.cern.ch"


### PR DESCRIPTION
Latest upstream images raise the following error
```
Leave $JUPYTERHUB_SINGLEUSER_APP unspecified (or use the default JUPYTERHUB_SINGLEUSER_APP=jupyter-server), and set `c.Spawner.default_url = "/tree"` to make notebook v7 the default UI.
```
Testing if config is compatible with old setup