### PR TITLE
Update jhub-release.yaml to chart v3.3.7

### DIFF
--- a/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
+++ b/infrastructure/cluster/flux-v2/jhub/jhub-release.yaml
@@ -14,7 +14,7 @@ spec:
         namespace: jhub
       chart: jupyterhub
       interval: 5m
-      version: 2.0.0
+      version: 3.3.7
   valuesFrom:
     - kind: Secret
       name: jhub-cvre-iam-secrets


### PR DESCRIPTION
Will install version `jupyterhub==4.1.5` (https://hub.jupyter.org/helm-chart/) 