### PR TITLE
hotfix:PR289

### DIFF
--- a/infrastructure/cluster/flux/jhub/jhub-release.yaml
+++ b/infrastructure/cluster/flux/jhub/jhub-release.yaml
@@ -46,6 +46,9 @@ spec:
       db:
         #upgrade: true
         type: postgres # passed as s secret (dbconnect string) from the jhub-vre-db secret
+      extraEnvFrom:
+        - secretRef:
+          name: jupyterhub-auth-state  # in the secret: export JUPYTERHUB_CRYPT_KEY=$(openssl rand -hex 32)
       config:
         JupyterHub:
           authenticator_class: "generic-oauth"
@@ -63,10 +66,6 @@ spec:
             - profile
             - email
             - offline_access
-          
-      extraEnvFrom:
-        - secretRef:
-          name: jupyterhub-auth-state  # in the secret: export JUPYTERHUB_CRYPT_KEY=$(openssl rand -hex 32)
 
       extraConfig:
 


### PR DESCRIPTION
cf: #289 (@Soap2G )

`extraEnvFrom` should be indented with `config`