### PR TITLE
Improve output iam-rucio-sync output

### DIFF
--- a/containers/iam-rucio-sync/sync_iam_rucio.py
+++ b/containers/iam-rucio-sync/sync_iam_rucio.py
@@ -281,6 +281,7 @@ if __name__ == '__main__':
 
         # get all users from IAM
         iam_users = syncer.get_list_of_users(access_token)
+        logging.info(f"Sync {len(iam_users)} users retrieved from IAM.")
 
         # DEBUG user output to file
         if debug:


### PR DESCRIPTION
by adding the number of found users that are when triggering the iam-rucio-sync cronjob.