### PR TITLE
remove terraform CI checks and change flux folder

### DIFF
--- a/.github/workflows/merge-check-always.yml
+++ b/.github/workflows/merge-check-always.yml
@@ -3,16 +3,9 @@ name: flux check pipeline # Merge Check Workflow for Terraform and Flux Files if
 on: 
   pull_request:
     paths-ignore:
-      - '**.tf'
-      - 'infrastructure/cluster/flux-v2/**'
+      - 'infrastructure/cluster/flux/**'
 
 jobs:
-  terraform-validate:
-    name: "Validate Terraform files"
-    runs-on: ubuntu-latest
-    steps:
-      - run: 'echo "No check required"'
-
   flux-validate:
     name: "Validate Flux files"
     runs-on: ubuntu-latest

--- a/.github/workflows/merge-check-paths.yml
+++ b/.github/workflows/merge-check-paths.yml
@@ -4,34 +4,14 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - '**.tf'
-      - 'infrastructure/cluster/flux-v2/**'
+      - 'infrastructure/cluster/flux/**'
   push:
     branches:
       - main
     paths:
-      - '**.tf'
-      - 'infrastructure/cluster/flux-v2/**'
+      - 'infrastructure/cluster/flux/**'
 
 jobs:
-  terraform-validate:
-    name: "Validate Terraform files"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Terraform Setup
-        uses: hashicorp/setup-terraform@v1
-
-      - name: Terraform Format
-        id: fmt
-        run: terraform fmt -check
-
-      - name: Terraform Validate
-        id: validate
-        run: terraform validate -no-color
-
   flux-validate:
     name: "Validate Flux files"
     runs-on: ubuntu-latest


### PR DESCRIPTION
TF is no longer used - since the cluster upgrade, where all the flux sync was also move to `infrastructure/cluster/flux`.

Closes #163 and #229  