### PR TITLE
fix: ISSUE #313 add podSecurityContext to avoid recursive chmod on storage mount

### DIFF
--- a/infrastructure/cluster/flux/jhub/jhub-release.yaml
+++ b/infrastructure/cluster/flux/jhub/jhub-release.yaml
@@ -41,6 +41,8 @@ spec:
       service:
         type: ClusterIP
     hub:
+      podSecurityContext:
+        fsGroupChangePolicy: OnRootMismatch
       service:
         type: ClusterIP
       # network policy needs to be modified to allow access to the Rucio server


### PR DESCRIPTION
Closes #313 